### PR TITLE
sort query paramaters to generate correct signature

### DIFF
--- a/py_nifty_cloud/nifty_cloud_request.py
+++ b/py_nifty_cloud/nifty_cloud_request.py
@@ -130,9 +130,10 @@ class NiftyCloudRequest(object):
 
     def __join_query(self, encoded_dict_query):
         ''' key=valueにして&でつなぐ
+        シグネチャ生成で使うためsortしておく
         '''
         return '&'.join(
-            '='.join(e) for e in (encoded_dict_query.items())
+            '='.join(e) for e in sorted(encoded_dict_query.items())
         )
 
     def __encode_query(self, dict_query):


### PR DESCRIPTION
- Avoid 'Unauthorized operations for signature.' error for query
  {'where': {'key': 'value'}, 'limit': 100, 'skip': 0}
- More preferred fix is to put them into 'signature_dict', but it is
  sufficient since keys in 'signature_dict' start with capital letter
  and query keys start with lowercase letter
